### PR TITLE
Free energy and generalized custom PFHub problems

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_executable(PFHub1a PFHub1a.cpp)
 target_link_libraries(PFHub1a LINK_PUBLIC CabanaPF)
-add_executable(PerformanceRuns GridTimer.cpp)
-target_link_libraries(PerformanceRuns LINK_PUBLIC CabanaPF)
+add_executable(ScalingAnalysis ScalingAnalysis.cpp)
+target_link_libraries(ScalingAnalysis LINK_PUBLIC CabanaPF)

--- a/examples/PFHub1a.cpp
+++ b/examples/PFHub1a.cpp
@@ -17,7 +17,7 @@ int main(int argc, char* argv[]) {
             std::unique_ptr<PFHub1aBase> simulation;
             std::string problem_name(argv[1]);
             if (problem_name == "benchmark")
-                simulation = std::make_unique<PFHub1aBenchmark>(grid_points, dt);
+                simulation = std::make_unique<PFHub1aBenchmark2017>(grid_points, dt);
             else if (problem_name == "2023")
                 simulation = std::make_unique<PFHub1aCHiMaD2023>(grid_points, dt);
             else

--- a/examples/PFHub1a.cpp
+++ b/examples/PFHub1a.cpp
@@ -18,15 +18,15 @@ int main(int argc, char* argv[]) {
             std::string problem_name(argv[1]);
             if (problem_name == "benchmark")
                 simulation = std::make_unique<PFHub1aBenchmark>(grid_points, dt);
-            else if (problem_name == "periodic")
-                simulation = std::make_unique<PFHub1aPeriodic>(grid_points, dt);
+            else if (problem_name == "2023")
+                simulation = std::make_unique<PFHub1aCHiMaD2023>(grid_points, dt);
             else
                 throw std::invalid_argument("");
 
             simulation->run_until_time(end_time);
             simulation->output_c();
         } catch (std::invalid_argument const&) {
-            std::cout << "Usage: ./PFHub1a <benchmark|periodic> <grid points> <dt> <end time>" << std::endl;
+            std::cout << "Usage: ./PFHub1a <benchmark|2023> <grid points> <dt> <end time>" << std::endl;
         }
     }
     MPI_Finalize();

--- a/examples/ScalingAnalysis.cpp
+++ b/examples/ScalingAnalysis.cpp
@@ -22,7 +22,7 @@ int main(int argc, char* argv[]) {
             for (int i = 3; i < argc; i++)
                 runs.push_back(std::stoi(argv[i]));
         } catch (std::invalid_argument const&) {
-            std::cout << "Usage: ./PerformanceRuns <dt> <end time> <grid points> [grid points ...]" << std::endl;
+            std::cout << "Usage: ./ScalingAnalysis <dt> <end time> <grid points> [grid points ...]" << std::endl;
             return 1;
         }
 
@@ -32,7 +32,7 @@ int main(int argc, char* argv[]) {
             std::cout << "Running " << runs[i] << " grid points" << std::endl;
             for (int reps = 0; reps < 5; reps++) {
                 timer.start(i);
-                PFHub1aPeriodic simul(runs[i], dt);
+                PFHub1aCHiMaD2023 simul(runs[i], dt);
                 simul.run_until_time(end_time);
                 timer.stop(i);
             }

--- a/src/PFHub.hpp
+++ b/src/PFHub.hpp
@@ -177,7 +177,7 @@ class PFHub1aBase : public CabanaPFRunner<2> {
     virtual ~PFHub1aBase() {}
 };
 
-class PFHub1aBenchmark : public PFHub1aBase {
+class PFHub1aBenchmark2017 : public PFHub1aBase {
   public:
     void initial_conditions() override {
         const auto c = vars[0]; // get View for scope capture
@@ -199,7 +199,7 @@ class PFHub1aBenchmark : public PFHub1aBase {
         return "1aBenchmark";
     }
 
-    PFHub1aBenchmark(int grid_points, double dt) : PFHub1aBase{grid_points, dt} {}
+    PFHub1aBenchmark2017(int grid_points, double dt) : PFHub1aBase{grid_points, dt} {}
 };
 
 class PFHub1aCustom : public PFHub1aBase {

--- a/src/PFHub.hpp
+++ b/src/PFHub.hpp
@@ -243,23 +243,6 @@ class PFHub1aCustom : public PFHub1aBase {
 // Our periodic proposal from the August 2023 CHiMaD meeting
 class PFHub1aCHiMaD2023 : public PFHub1aCustom {
   public:
-    void initial_conditions() override {
-        const auto c = vars[0]; // get View for scope capture
-        const auto delta = cell_size;
-        node_parallel_for(
-            "periodic initial conditions", KOKKOS_LAMBDA(const int i, const int j) {
-                // initialize c:
-                const double x = delta * i;
-                const double y = delta * j;
-                c(i, j, 0) = .5 + .01 * (Kokkos::cos(3 * M_PI * x / 100) * Kokkos::cos(M_PI * y / 25) +
-                                         Kokkos::cos(M_PI * x / 25) * Kokkos::cos(3 * M_PI * y / 100) *
-                                             Kokkos::cos(M_PI * x / 25) * Kokkos::cos(3 * M_PI * y / 100) +
-                                         Kokkos::cos(M_PI * x / 100 - M_PI * y / 20) *
-                                             Kokkos::cos(M_PI * x / 50 - M_PI * y / 100));
-                c(i, j, 1) = 0;
-            });
-    }
-
     std::string subproblem_name() const override {
         return "1aCHiMaD2023";
     }

--- a/src/Runner.hpp
+++ b/src/Runner.hpp
@@ -86,6 +86,10 @@ class CabanaPFRunner {
         return timesteps_done;
     }
 
+    double get_time_done() const {
+        return dt * timesteps_done;
+    }
+
     // Children inherit from this class and implement these:
     virtual void initialize() {} // Called once, before taking the first timestep
     virtual void step() {}       // Called to take a timestep

--- a/unit_test/test.cpp
+++ b/unit_test/test.cpp
@@ -103,8 +103,36 @@ TEST(PFVariables, saveload) {
 }
 
 // Similar to above, the python implementation was modified to use the periodic initial conditions
-TEST(PFHub1aPeriodic, periodic) {
-    PFHub1aPeriodic simulation(96, .5);
+TEST(PFHub1aCHiMaD2023, FullRun) {
+    PFHub1aCHiMaD2023 simulation(96, .5);
+    simulation.initialize();
+    auto results = simulation.get_cpu_view();
+    EXPECT_NEAR(0.53, results(0, 0, 0), 1e-9);
+    EXPECT_NEAR(0.5280872555770657, results(95, 95, 0), 1e-9);
+    EXPECT_NEAR(0.49625, results(56, 52, 0), 1e-9);
+    EXPECT_NEAR(0.5096103712433676, results(39, 36, 0), 1e-9);
+    EXPECT_NEAR(0.5122826024701564, results(46, 40, 0), 1e-9);
+
+    simulation.run_until_time(.5);
+    results = simulation.get_cpu_view();
+    EXPECT_NEAR(0.5316722086053631, results(0, 0, 0), 1e-9);
+    EXPECT_NEAR(0.5296339912527902, results(95, 95, 0), 1e-9);
+    EXPECT_NEAR(0.5155424558547776, results(24, 46, 0), 1e-9);
+    EXPECT_NEAR(0.510243048825588, results(87, 78, 0), 1e-9);
+    EXPECT_NEAR(0.5092351158827323, results(6, 19, 0), 1e-9);
+
+    simulation.run_until_steps(500);
+    results = simulation.get_cpu_view();
+    EXPECT_NEAR(0.6993369106233298, results(0, 0, 0), 1e-9);
+    EXPECT_NEAR(0.7014658707445363, results(95, 95, 0), 1e-9);
+    EXPECT_NEAR(0.6427344294446387, results(0, 28, 0), 1e-9);
+    EXPECT_NEAR(0.6076503841641254, results(35, 65, 0), 1e-9);
+    EXPECT_NEAR(0.3520246964993546, results(74, 32, 0), 1e-9);
+}
+
+// This is a copy of the PFHub1aCHiMaD2023 test case, using PFHub1aCustom to recreate those conditions
+TEST(PFHub1aCustom, 2023) {
+    PFHub1aCustom simulation(96, .5, 3, 4, 8, 6, 1, 5, 2, 1, 0, 0);
     simulation.initialize();
     auto results = simulation.get_cpu_view();
     EXPECT_NEAR(0.53, results(0, 0, 0), 1e-9);

--- a/unit_test/test.cpp
+++ b/unit_test/test.cpp
@@ -13,8 +13,8 @@ These results that are being tested against come from the python implementation 
 PFHub1a Available here (ORNL internal): https://code.ornl.gov/71d/phase-field-example-codes Most points were randomly
 selected
 */
-TEST(PFHub1a, Initialization) {
-    PFHub1aBenchmark simulation(96, .5);
+TEST(PFHub1aBenchmark2017, Initialization) {
+    PFHub1aBenchmark2017 simulation(96, .5);
     simulation.initialize(); // trigger initialization
     auto results = simulation.get_cpu_view();
     //"true results" come from python implementation (see previous comment)
@@ -40,7 +40,7 @@ TEST(PFHub1a, Initialization) {
 }
 
 TEST(PFHub1a, OneTimestep) {
-    PFHub1aBenchmark simulation(96, .5);
+    PFHub1aBenchmark2017 simulation(96, .5);
     simulation.run_until_steps(1);
     auto results = simulation.get_cpu_view();
     // test at extreme points and 10 random points.  Correct values come from python implementation (see above)
@@ -59,7 +59,7 @@ TEST(PFHub1a, OneTimestep) {
 }
 
 TEST(PFHub1a, AllTimestep) {
-    PFHub1aBenchmark simulation(96, .5);
+    PFHub1aBenchmark2017 simulation(96, .5);
     simulation.run_for_steps(500);
     auto results = simulation.get_cpu_view();
     // as before, (0,0), (95,95), and 10 random points, testing against python
@@ -106,9 +106,9 @@ TEST(PFVariables, saveload) {
     }
 }
 
-// Similar to above, the python implementation was modified to use the periodic initial conditions
-TEST(PFHub1aCHiMaD2023, FullRun) {
-    PFHub1aCHiMaD2023 simulation(96, .5);
+// Helper function to test CHiMaD2023 proposal and PFHub1aCustom's recreation of those
+template <class Problem>
+void test_periodic(Problem& simulation) {
     simulation.initialize();
     auto results = simulation.get_cpu_view();
     EXPECT_NEAR(0.53, results(0, 0, 0), 1e-9);
@@ -134,32 +134,16 @@ TEST(PFHub1aCHiMaD2023, FullRun) {
     EXPECT_NEAR(0.3520246964993546, results(74, 32, 0), 1e-9);
 }
 
+// Similar to above, the python implementation was modified to use the periodic initial conditions
+TEST(PFHub1aCHiMaD2023, FullRun) {
+    PFHub1aCHiMaD2023 simulation(96, .5);
+    test_periodic(simulation);
+}
+
 // This is a copy of the PFHub1aCHiMaD2023 test case, using PFHub1aCustom to recreate those conditions
 TEST(PFHub1aCustom, 2023) {
     PFHub1aCustom simulation(96, .5, 3, 4, 8, 6, 1, 5, 2, 1, 0, 0);
-    simulation.initialize();
-    auto results = simulation.get_cpu_view();
-    EXPECT_NEAR(0.53, results(0, 0, 0), 1e-9);
-    EXPECT_NEAR(0.5280872555770657, results(95, 95, 0), 1e-9);
-    EXPECT_NEAR(0.49625, results(56, 52, 0), 1e-9);
-    EXPECT_NEAR(0.5096103712433676, results(39, 36, 0), 1e-9);
-    EXPECT_NEAR(0.5122826024701564, results(46, 40, 0), 1e-9);
-
-    simulation.run_until_time(.5);
-    results = simulation.get_cpu_view();
-    EXPECT_NEAR(0.5316722086053631, results(0, 0, 0), 1e-9);
-    EXPECT_NEAR(0.5296339912527902, results(95, 95, 0), 1e-9);
-    EXPECT_NEAR(0.5155424558547776, results(24, 46, 0), 1e-9);
-    EXPECT_NEAR(0.510243048825588, results(87, 78, 0), 1e-9);
-    EXPECT_NEAR(0.5092351158827323, results(6, 19, 0), 1e-9);
-
-    simulation.run_until_steps(500);
-    results = simulation.get_cpu_view();
-    EXPECT_NEAR(0.6993369106233298, results(0, 0, 0), 1e-9);
-    EXPECT_NEAR(0.7014658707445363, results(95, 95, 0), 1e-9);
-    EXPECT_NEAR(0.6427344294446387, results(0, 28, 0), 1e-9);
-    EXPECT_NEAR(0.6076503841641254, results(35, 65, 0), 1e-9);
-    EXPECT_NEAR(0.3520246964993546, results(74, 32, 0), 1e-9);
+    test_periodic(simulation);
 }
 
 int main(int argc, char** argv) {

--- a/unit_test/test.cpp
+++ b/unit_test/test.cpp
@@ -35,6 +35,8 @@ TEST(PFHub1a, Initialization) {
     EXPECT_DOUBLE_EQ(0.5013653249684705, results(33, 6, 0));
     EXPECT_DOUBLE_EQ(0.5173210860478162, results(84, 82, 0));
     EXPECT_DOUBLE_EQ(0.48901386854420836, results(26, 42, 0));
+
+    EXPECT_NEAR(319.1097966931092, simulation.free_energy(), 1e-9);
 }
 
 TEST(PFHub1a, OneTimestep) {
@@ -73,6 +75,8 @@ TEST(PFHub1a, AllTimestep) {
     EXPECT_NEAR(0.4279715141345520, results(40, 78, 0), 1e-9);
     EXPECT_NEAR(0.6966615561225524, results(70, 72, 0), 1e-9);
     EXPECT_NEAR(0.6482746495041702, results(67, 7, 0), 1e-9);
+
+    EXPECT_NEAR(112.93083808600322, simulation.free_energy(), 1e-9);
 }
 
 TEST(PFVariables, saveload) {


### PR DESCRIPTION
Closes #2 .  The executable changes were getting big enough that I decided to split them off to a new branch.

- Added `PFHub1aBase.free_energy`: Calculates the free energy based on the current c grid.
  - Note: This does include an extra FFT per free energy calculation than MEUMAPPS' approach
  - Includes test cases that match the python notebook

- Added `PFHub1aCustom`: Initial Conditions presented at the March meeting (including the +sinx +siny) with user-specified coefficients
  - Renamed `PFHub1aPeriodic` -> ~~`PFHub1aAugust`~~ `PFHub1aCHiMaD2023` and made it a child of PFHub1aCustom

- While addressing review concerns, wound up discovering and fixing a bug introduced by #14 
  - Bug was that every output would overwrite the t=0 output, instead of outputting with the correct number of timesteps