### PR TITLE
CI: run on ubuntu-latest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
         backend: ['SERIAL', 'OPENMP']
         cmake_build_type: ['Debug', 'Release']
         kokkos_ver: ['4.1.00']
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ghcr.io/ecp-copa/ci-containers/${{ matrix.distro }}
     steps:
       - name: Checkout kokkos
@@ -103,7 +103,7 @@ jobs:
         cxx: ['nvcc']
         cmake_build_type: ['Release']
         kokkos_ver: ['4.1.00']
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ghcr.io/ecp-copa/ci-containers/cuda:12.2.0
     steps:
       - name: Checkout kokkos

--- a/.github/workflows/Weekly.yml
+++ b/.github/workflows/Weekly.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         backend: ["OPENMP", "SERIAL"]
         cmake_build_type: ['Release']
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ghcr.io/ecp-copa/ci-containers/ubuntu:latest
     steps:
       - name: Checkout kokkos


### PR DESCRIPTION
20.04 is being retired; avoid having to do this in the future with latest
